### PR TITLE
urage_undefine_type(db, type_name) and fixed link typo in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ URAGE works with .dat and .idx files to save data. It supports *ACID properties*
     
     # 2. Download and build
 
-    git clone https://github.com/yourname/urage.git
+    git clone https://github.com/abdullahtnz/urage.git
     cd urage
     mkdir build
     cd build

--- a/cli/src/main.c
+++ b/cli/src/main.c
@@ -168,8 +168,14 @@ if (strcmp(cmd, "define") == 0) {
 }
         else if (strcmp(cmd, "undefine") == 0) {
             if (sscanf(line, "undefine %63s", type_name) == 1) {
-                printf("Deleting type '%s'\n", type_name);
-                // TODO: Call urage_undefine_type
+                urage_result_t r = urage_undefine_type(db, type_name);
+                if (r == URAGE_OK) {
+                    printf("✅ Type '%s' deleted\n", type_name);
+                } else if (r == URAGE_NOT_FOUND) {
+                    printf("❌ Type '%s' does not exist\n", type_name);
+                } else {
+                    printf("❌ Failed to delete type '%s' (error %d)\n", type_name, r);
+                }
             } else {
                 printf("Usage: undefine <name>\n");
             }

--- a/cli/src/main.c
+++ b/cli/src/main.c
@@ -269,7 +269,9 @@ if (strcmp(cmd, "define") == 0) {
                 size_t size = sizeof(buffer);
                 urage_result_t r = urage_get(db, key, buffer, &size);
                 if (r == URAGE_OK) {
-                    buffer[size] = '\0';
+                    // Clamp to valid index if returned size fills the buffer.
+                    size_t end = (size < sizeof(buffer)) ? size : (sizeof(buffer) - 1);
+                    buffer[end] = '\0'; // works
                     printf("%u -> %s\n", key, buffer);
                 } else if (r == URAGE_NOT_FOUND) {
                     printf("Key %u not found\n", key);
@@ -322,7 +324,9 @@ else if (strcmp(cmd, "gets") == 0) {
         size_t size = sizeof(buffer);
         urage_result_t r = urage_get_str(db, str_key, buffer, &size);
         if (r == URAGE_OK) {
-            buffer[size] = '\0';
+            // Clamp to valid index if returned size fills the buffer.
+            size_t end = (size < sizeof(buffer)) ? size : (sizeof(buffer) - 1);
+            buffer[end] = '\0';
             printf("'%s' -> %s\n", str_key, buffer);
         } else if (r == URAGE_NOT_FOUND) {
             printf("Key '%s' not found\n", str_key);


### PR DESCRIPTION
hey dear contributor :heart:
i was scrolling through your repo and i saw you had a todo for undefine type call in cli, so i wanted to gain some sabab points and i wrote the code for the call myself :D
i added urage_undefine_type(db, type_name) inside the undefine command in cli/src/main.c and handled the main results too: success, type not found, and generic error code print.
before this, undefine was only printing message and doing nothing, now it actually deletes the type definition from db.
i also kept the existing cli style for output so it feels same with other commands.
i hope you like it g